### PR TITLE
fix the reset command to not reset the prompt

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -8,9 +8,9 @@ on:
       - 'package.json'
 
 jobs:
-  to_gitlab:
+  push_image:
     runs-on: ubuntu-latest
-    steps:                                              # <-- must use actions/checkout before mirroring!
+    steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.env
+*.env
 node_modules

--- a/index.js
+++ b/index.js
@@ -370,7 +370,7 @@ client.on('messageCreate', async msg => {
 
     // Reset bot command
 	if (msg.content.startsWith(botCommand + 'reset')) {
-        // Check disabled status
+		// Check disabled status
 		if (client.isPaused === true && !isAdmin(msg)) {
 			sendCmdResp(msg, process.env.DISABLED_MSG);
 			return;
@@ -386,7 +386,8 @@ client.on('messageCreate', async msg => {
 			for (let i = 0; i < personalities.length; i++) {
 				let thisPersonality = personalities[i];
 				if (cutMsg.toUpperCase().startsWith(thisPersonality.name.toUpperCase())) {
-					personalities[i] = { "name": thisPersonality.name, "request" : [{"role": "system", "content": `${process.env["personality." + thisPersonality.name]}`}]};
+					let originalSystemMessage = thisPersonality.request.find(msg => msg.role === 'system');
+					personalities[i] = { "name": thisPersonality.name, "request" : [originalSystemMessage]};
 					sendCmdResp(msg, process.env.DYNAMIC_RESET_MSG.replace('<p>', thisPersonality.name));
 					return;
 				}


### PR DESCRIPTION
When a user would use the reset command, the personality would be reset, but the prompt would be too. this fixes it,