### PR TITLE
fix personalities not working after a reset

### DIFF
--- a/index.js
+++ b/index.js
@@ -402,26 +402,28 @@ client.on('messageCreate', async msg => {
 	if (msg.content === botCommand + 'personalities') {
 		// Check disabled status
 		if (client.isPaused === true && !isAdmin(msg)) {
-			sendCmdResp(msg, process.env.DISABLED_MSG);
-			return;
+		  sendCmdResp(msg, process.env.DISABLED_MSG);
+		  return;
 		}
 		// Create an embed object
 		let persEmbed = new EmbedBuilder()
-			.setColor(0x0099FF) // set the color of the embed
-			.setTitle(process.env.PERSONALITY_MSG) // set the title of the embed
-			.setDescription('Here are some personalities and their prompts'); // set the description of the embed
-	
+		  .setColor(0x0099FF) // set the color of the embed
+		  .setTitle(process.env.PERSONALITY_MSG) // set the title of the embed
+		  .setDescription('Here are some personalities and their prompts'); // set the description of the embed
+	  
 		// Add personality names and prompts to fields
 		for (let i = 0; i < personalities.length; i++) {
-			let thisPersonality = personalities[i];
-			// Truncate the prompt to 1024 characters if it's longer than that
-			let truncatedPrompt = thisPersonality.prompt.substring(0, 1024);
-			persEmbed.addFields({ name: thisPersonality.name, value: truncatedPrompt });
+		  let thisPersonality = personalities[i];
+		  // Find the prompt from the request array
+		  let prompt = thisPersonality.request.find(item => item.role === 'system').content;
+		  // Truncate the prompt to 1024 characters if it's longer than that
+		  let truncatedPrompt = prompt.substring(0, 1024);
+		  persEmbed.addFields({ name: thisPersonality.name, value: truncatedPrompt });
 		}
-	
+	  
 		// Send the embed
-		sendCmdResp(msg,{embeds:[persEmbed]});
-	}
+		sendCmdResp(msg, { embeds: [persEmbed] });
+	  }
 
 	if (msg.content.startsWith(botCommand + 'say')) {
 		const input = msg.content.split(' ').slice(1);


### PR DESCRIPTION
```
It seems like the issue might be related to the thisPersonality.prompt property that is being used in the personality command. However, there is no prompt property in the personalities objects in the provided code.

I assume that you meant to use the request property instead of the prompt property when displaying the personalities and their prompts. You can try modifying the personality command like this:
```